### PR TITLE
🐛 Fixed the missing "/" of the directory and tag links

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -42,7 +42,7 @@
             
             {{ if not (in $allSecondaryCats $primaryCategory) }}
               <li class="category-list-item">
-                <a class="category-list-link" href="{{ "categories/" | relURL }}{{ $primaryCategory | urlize }}">
+                <a class="category-list-link" href="{{ "categories/" | relURL }}{{ $primaryCategory | urlize }}/">
                   {{ $primaryCategory }}
                   <span class="category-list-count">{{ $primaryCount }}</span>
                 </a>
@@ -57,7 +57,7 @@
                     {{ end }}
                   {{ end }}
                   <li class="category-children-list-item">
-                    <a class="category-list-link" href="{{ "categories/" | relURL }}{{ . | urlize }}">
+                    <a class="category-list-link" href="{{ "categories/" | relURL }}{{ . | urlize }}/">
                       {{ . }}
                       <span class="category-list-count">{{ $secondaryCount }}</span>
                     </a>
@@ -77,7 +77,7 @@
         <div class="tag-cloud-tags">
           {{ $randNums := (seq 10) }}
           {{- range $name, $items := $tags }}
-          <a class="tag-cloud-{{ index (shuffle $randNums) 0 }}" href="{{ "/tags/" | relLangURL }}{{ $name | urlize  }}">{{ .Page.Title }}
+          <a class="tag-cloud-{{ index (shuffle $randNums) 0 }}" href="{{ "/tags/" | relLangURL }}{{ $name | urlize  }}/">{{ .Page.Title }}
             <span class="tag-list-count">
               <sup>({{ len $items }})</sup>
             </span>


### PR DESCRIPTION
Missing "/" will lead to an extra 301 and not friendly to search engines.
<img width="307" alt="image" src="https://github.com/chn-lee-yumi/hugo-theme-next/assets/20398519/f4504471-c694-4758-b76d-a1b6fdb88ff3">
